### PR TITLE
⬇️⬆️ Update dependencies min versions for cli

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 dependencies = [
-    "aiobotocore>=3.2.1",
-    "httpx>=0.28.1",
-    "stamina>=24.3.0",
-    "typer>=0.15.0",
+    "aiobotocore>=2.13.0",
+    "httpx>=0.24.0",
+    "stamina>=23.1.0",
+    "typer>=0.16.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-25T15:19:16.048020208Z"
+exclude-newer = "2026-05-01T19:37:27.773690117Z"
 exclude-newer-span = "P1W"
 
 [manifest]
@@ -446,10 +446,10 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiobotocore", specifier = ">=3.2.1" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "stamina", specifier = ">=24.3.0" },
-    { name = "typer", specifier = ">=0.15.0" },
+    { name = "aiobotocore", specifier = ">=2.13.0" },
+    { name = "httpx", specifier = ">=0.24.0" },
+    { name = "stamina", specifier = ">=23.1.0" },
+    { name = "typer", specifier = ">=0.16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Typer min version is raised as lower versions have conflict with Click 8.2.
Other dependency min versions are relaxed