### PR TITLE
🐛 Fix `TaskGroup` incompatible with python 3.10

### DIFF
--- a/cli/src/covered/cli.py
+++ b/cli/src/covered/cli.py
@@ -13,11 +13,7 @@ from aiobotocore.session import get_session
 app = typer.Typer()
 
 
-# TODO: review templates
-COV_PATTERNS = [
-    re.compile(r'<span\s+class="pc_cov">\s*([\d.]+)%\s*</span>'),
-    re.compile(r"<li><b>Coverage</b>:\s*([\d.]+)%</li>"),
-]
+COV_PATTERN = re.compile(r'<span\s+class="pc_cov">\s*([\d.]+)%\s*</span>')
 
 
 def _get_coverage_info(cov_report_path: Path) -> float | None:
@@ -25,12 +21,9 @@ def _get_coverage_info(cov_report_path: Path) -> float | None:
 
     if not cov_index.exists():
         return None
-    with open(cov_index, "r") as f:
-        html = f.read()
-    for pattern in COV_PATTERNS:
-        m = pattern.search(html)
-        if m:
-            return float(m.group(1))
+    m = COV_PATTERN.search(cov_index.read_text())
+    if m:
+        return float(m.group(1))
     return None
 
 

--- a/cli/src/covered/cli.py
+++ b/cli/src/covered/cli.py
@@ -80,9 +80,13 @@ async def _upload_files(
                     Body=file_path.read_bytes(),
                 )
 
-        async with asyncio.TaskGroup() as tg:
-            for f in files:
-                tg.create_task(upload_one(f))
+        results = await asyncio.gather(
+            *(upload_one(f) for f in files),
+            return_exceptions=True,
+        )
+        for r in results:
+            if isinstance(r, BaseException):
+                raise r
 
     return len(files)
 


### PR DESCRIPTION
Fix `TaskGroup` incompatible with python 3.10.

Also dropped the alternative coverage value extraction pattern